### PR TITLE
Disable hotkeys when active element is editable

### DIFF
--- a/global.js
+++ b/global.js
@@ -92,7 +92,7 @@ function onTextTyped (key) {
 }
 
 function isCurrentlyInInput () {
-  return document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA'
+  return document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA' || document.activeElement.isContentEditable
 }
 
 document.addEventListener('keydown', function (e) {
@@ -109,16 +109,15 @@ document.addEventListener('keydown', function (e) {
   }
 })
 
-// Use j to scroll down
+
 window.addEventListener('keypress', function (e) {
-  if (e.keyCode === 106 && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
+  // Use j to scroll down
+  if (e.keyCode === 106 && !isCurrentlyInInput ()) {
     window.scrollBy(0, 60)
     e.preventDefault()
   }
-})
-// Use k to scroll up
-window.addEventListener('keypress', function (e) {
-  if (e.keyCode === 107 && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
+  // Use k to scroll up
+  if (e.keyCode === 107 && !sCurrentlyInInput ()) {
     window.scrollBy(0, -60)
     e.preventDefault()
   }

--- a/global.js
+++ b/global.js
@@ -110,14 +110,16 @@ document.addEventListener('keydown', function (e) {
 })
 
 
+// Use j to scroll down
 window.addEventListener('keypress', function (e) {
-  // Use j to scroll down
-  if (e.keyCode === 106 && !isCurrentlyInInput ()) {
+  if (e.keyCode === 106 && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
     window.scrollBy(0, 60)
     e.preventDefault()
   }
-  // Use k to scroll up
-  if (e.keyCode === 107 && !sCurrentlyInInput ()) {
+})
+// Use k to scroll up
+window.addEventListener('keypress', function (e) {
+  if (e.keyCode === 107 && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
     window.scrollBy(0, -60)
     e.preventDefault()
   }

--- a/global.js
+++ b/global.js
@@ -109,7 +109,6 @@ document.addEventListener('keydown', function (e) {
   }
 })
 
-
 // Use j to scroll down
 window.addEventListener('keypress', function (e) {
   if (e.keyCode === 106 && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {


### PR DESCRIPTION
When an contenteditable element is active, also disable the bindings.