### PR TITLE
focus/unfocus on input/textarea elements

### DIFF
--- a/global.js
+++ b/global.js
@@ -103,7 +103,7 @@ function onTextTyped (key) {
         }
       } else if (link.link.tagName === 'BUTTON') {
         link.link.click()
-      } else if (['INPUT','TEXTAREA'].indexOf(link.link.tagName) >= 0) {
+      } else if (isCurrentlyInInput()) {
         link.link.focus();
       }
       hideLinkKeys()
@@ -171,7 +171,7 @@ document.addEventListener('keyup', function (e) {
   if (e.key === 'Escape' && isLinkKeyMode) {
     hideLinkKeys()
     blockKeybindings.blur()
-  } else if (e.key === 'Escape' && ['INPUT','TEXTAREA'].indexOf(e.target.tagName) >= 0) {
+  } else if (e.key === 'Escape' && isCurrentlyInInput()) {
     e.target.blur();
   } else if (!isCurrentlyInInput() && !isLinkKeyMode && commandChars.has(e.key)) {
     command += e.key

--- a/global.js
+++ b/global.js
@@ -105,7 +105,7 @@ function onTextTyped (key) {
         link.link.click()
       } else if (isFocusable(link.link)) {
         link.link.focus();
-        if(['checkbox','radio'].indexOf(link.link.attributes.getNamedItem('type').value.toLowerCase()) >= 0) {
+        if(['checkbox','radio'].indexOf(link.link.getAttribute('type').toLowerCase()) >= 0) {
           link.link.click();
           document.activeElement.blur();
         }

--- a/global.js
+++ b/global.js
@@ -61,7 +61,7 @@ function showLinkKeys () {
   var links = []
   var linkRects = [];
 
-  [].slice.call(document.querySelectorAll('a, button')).forEach(function (link) {
+  [].slice.call(document.querySelectorAll('a, button, input, textarea')).forEach(function (link) {
     var rect = link.getBoundingClientRect()
     if (isVisible(rect)) {
       links.push(link)
@@ -103,6 +103,8 @@ function onTextTyped (key) {
         }
       } else if (link.link.tagName === 'BUTTON') {
         link.link.click()
+      } else if (['INPUT','TEXTAREA'].indexOf(link.link.tagName) >= 0) {
+        link.link.focus();
       }
       hideLinkKeys()
       // It is critical that we do NOT blur blockKeybindings here
@@ -169,6 +171,8 @@ document.addEventListener('keyup', function (e) {
   if (e.key === 'Escape' && isLinkKeyMode) {
     hideLinkKeys()
     blockKeybindings.blur()
+  } else if (e.key === 'Escape' && ['INPUT','TEXTAREA'].indexOf(e.target.tagName) >= 0) {
+    e.target.blur();
   } else if (!isCurrentlyInInput() && !isLinkKeyMode && commandChars.has(e.key)) {
     command += e.key
     var match = true

--- a/global.js
+++ b/global.js
@@ -61,7 +61,7 @@ function showLinkKeys () {
   var links = []
   var linkRects = [];
 
-  [].slice.call(document.querySelectorAll('a, button, input, textarea')).forEach(function (link) {
+  [].slice.call(document.querySelectorAll('a, button, input, textarea, select')).forEach(function (link) {
     var rect = link.getBoundingClientRect()
     if (isVisible(rect)) {
       links.push(link)
@@ -103,8 +103,15 @@ function onTextTyped (key) {
         }
       } else if (link.link.tagName === 'BUTTON') {
         link.link.click()
-      } else if (isCurrentlyInInput()) {
+      } else if (isFocusable(link.link)) {
         link.link.focus();
+        if(['checkbox','radio'].indexOf(link.link.attributes.getNamedItem('type').value.toLowerCase()) >= 0) {
+          link.link.click();
+          document.activeElement.blur();
+        }
+        else if(link.link.tagName === 'SELECT') {
+          link.link.click();
+        }
       }
       hideLinkKeys()
       // It is critical that we do NOT blur blockKeybindings here
@@ -138,6 +145,10 @@ document.addEventListener('visibilitychange', function () {
 
 function isCurrentlyInInput () {
   return document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA' || document.activeElement.isContentEditable
+}
+
+function isFocusable(element) {
+  return ['INPUT','TEXTAREA','SELECT'].indexOf(element.tagName) >= 0 || element.isContentEditable;
 }
 
 function copyUrlToClipboard () {


### PR DESCRIPTION
Pressing `f`/`F` will now display hints on input/textarea elements as well as links/buttons. Pressing the appropriate key-combo will focus on the input/textarea element. Pressing `ESC` while focused on an input or textarea element is stop focusing on that particular element (`.blur()`).