### PR TITLE
add keybinding "cc" for copy-to-clipboard functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Adds Vim-style shortcuts to [Min](https://github.com/minbrowser/min):
 
 * Press f to search for links (or F to open the link in a new tab)
-* Press cc to copy a link to the clipboard
+* Press c to copy a link to the clipboard
 * Press j to scroll down
 * Press k to scroll up
 * Press gg to scroll to the top

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Adds Vim-style shortcuts to [Min](https://github.com/minbrowser/min):
 
 * Press f to search for links (or F to open the link in a new tab)
+* Press c to copy a link to the clipboard
 * Press j to scroll down
 * Press k to scroll up
 * Press gg to scroll to the top

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Adds Vim-style shortcuts to [Min](https://github.com/minbrowser/min):
 
 * Press f to search for links (or F to open the link in a new tab)
-* Press c to copy a link to the clipboard
+* Press cc to copy a link to the clipboard
 * Press j to scroll down
 * Press k to scroll up
 * Press gg to scroll to the top

--- a/vim-mode.js
+++ b/vim-mode.js
@@ -49,7 +49,7 @@ function getNextKeyCombination (index) {
 
 var currentLinkItems = []
 var isLinkKeyMode = false
-var openLinkNewTab = false
+var linkAction = null
 var typedText = ''
 
 // This ensures blockKeybindings doesn't get blurred because of
@@ -102,7 +102,14 @@ function onTextTyped (key) {
     if (link.key === typedText) {
       viableElementRemaining = true
       if (link.link.tagName === 'A') {
-        if (openLinkNewTab) {
+        if (linkAction === "copyToClipboard") {
+          var dummy = document.createElement('input')
+          dummy.value = link.link.href
+          document.body.appendChild(dummy)
+          dummy.select()
+          document.execCommand('copy')
+          document.body.removeChild(dummy)
+        } else if (linkAction == "openInNewTab") {
           window.open(link.link.href)
         } else {
           window.open(link.link.href, '_top')
@@ -181,7 +188,7 @@ document.addEventListener('keydown', function (e) {
   }
 })
 
-const commandChars = new Set(['f', 'F', 'y', 'g', 'G'])
+const commandChars = new Set(['f', 'F', 'c', 'y', 'g', 'G'])
 const linkChars = new Set(alphabet)
 document.addEventListener('keyup', function (e) {
   if (e.key === 'Escape' && isLinkKeyMode) {
@@ -196,12 +203,18 @@ document.addEventListener('keyup', function (e) {
       case 'f':
         showLinkKeys()
         blockKeybindings.select()
-        openLinkNewTab = false
+        linkAction = 'open'
         break
       case 'F':
         showLinkKeys()
         blockKeybindings.select()
-        openLinkNewTab = true
+        linkAction = 'openInNewTab'
+        break
+     // use c to copy a link to the clipboard, using the GUI for link navigation
+     case 'c':
+        showLinkKeys()
+        blockKeybindings.select()
+        linkAction = 'copyToClipboard'
         break
       // Use j to scroll down
       case 'j':

--- a/vim-mode.js
+++ b/vim-mode.js
@@ -109,7 +109,7 @@ function onTextTyped (key) {
           dummy.select()
           document.execCommand('copy')
           document.body.removeChild(dummy)
-        } else if (linkAction == "openInNewTab") {
+        } else if (linkAction === "openInNewTab") {
           window.open(link.link.href)
         } else {
           window.open(link.link.href, '_top')
@@ -188,7 +188,7 @@ document.addEventListener('keydown', function (e) {
   }
 })
 
-const commandChars = new Set(['f', 'F', 'c', 'y', 'g', 'G'])
+const commandChars = new Set(['f', 'F', 'y', 'g', 'G', 'c'])
 const linkChars = new Set(alphabet)
 document.addEventListener('keyup', function (e) {
   if (e.key === 'Escape' && isLinkKeyMode) {
@@ -210,7 +210,7 @@ document.addEventListener('keyup', function (e) {
         blockKeybindings.select()
         linkAction = 'openInNewTab'
         break
-     // use c to copy a link to the clipboard, using the GUI for link navigation
+     // use c to copy a link to the clipboard
      case 'c':
         showLinkKeys()
         blockKeybindings.select()

--- a/vim-mode.js
+++ b/vim-mode.js
@@ -196,7 +196,7 @@ document.addEventListener('keyup', function (e) {
     blockKeybindings.blur()
   } else if (e.key === 'Escape' && isCurrentlyInInput()) {
     e.target.blur()
-  } else if (!isCurrentlyInInput() && !isLinkKeyMode && commandChars.has(e.key)) {
+  }  else if (!isCurrentlyInInput() && !isLinkKeyMode && commandChars.has(e.key) && !e.ctrlKey && !e.metaKey) {
     command += e.key
     var match = true
     switch (command) {
@@ -211,7 +211,7 @@ document.addEventListener('keyup', function (e) {
         linkAction = 'openInNewTab'
         break
      // use c to copy a link to the clipboard
-     case 'cc':
+     case 'c':
         showLinkKeys()
         blockKeybindings.select()
         linkAction = 'copyToClipboard'

--- a/vim-mode.js
+++ b/vim-mode.js
@@ -211,7 +211,7 @@ document.addEventListener('keyup', function (e) {
         linkAction = 'openInNewTab'
         break
      // use c to copy a link to the clipboard
-     case 'c':
+     case 'cc':
         showLinkKeys()
         blockKeybindings.select()
         linkAction = 'copyToClipboard'


### PR DESCRIPTION
This pull request adds the option to copy a link to the clipboard using keybinding "c".  It works just like "f" or "F" but copies the link instead of navigating to it.

It also gets rid of the `openLinkNewTab` variable, replacing that with `linkAction` for a more general action selector, so future contributors can do other things with a selected link.
 
 