### PR TITLE
Add `d` and `u` Vim commands to `vim-mode.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Adds Vim-style shortcuts to [Min](https://github.com/minbrowser/min):
 * Press f to search for links (or F to open the link in a new tab)
 * Press c to copy a link to the clipboard
 * Press j to scroll down
+* Press d to scroll down faster
 * Press k to scroll up
+* Press u to scroll up faster
 * Press gg to scroll to the top
 * Press G to scroll to the bottom
 * Press yy to copy the current url

--- a/vim-mode.js
+++ b/vim-mode.js
@@ -179,7 +179,7 @@ function copyUrlToClipboard () {
 
 // When using the "j" or "k" Vim commands. (j = down, k = up)
 const scrollAmount = 60
-// When usin the "d" or "u" Vim commands. (d = down, u = up)
+// When using the "d" or "u" Vim commands. (d = down, u = up)
 const quickScrollAmount = 400
 
 // We put scrolling here in keydown, so that we can continously press it.

--- a/vim-mode.js
+++ b/vim-mode.js
@@ -177,19 +177,27 @@ function copyUrlToClipboard () {
 // We should provide means to disable the keybings for a blacklist of websites
 // github.com for example has a lot of vim-like bindings of its own.
 
+// When using the "j" or "k" Vim commands. (j = down, k = up)
+const scrollAmount = 60
+// When usin the "d" or "u" Vim commands. (d = down, u = up)
+const quickScrollAmount = 400
+
 // We put scrolling here in keydown, so that we can continously press it.
 document.addEventListener('keydown', function (e) {
-  if ((e.key === 'j' || e.key === 'k') && !isLinkKeyMode && !isCurrentlyInInput()) {
+  if ((e.key === 'j' || e.key === 'k' || e.key === 'd' || e.key === 'u') && !isLinkKeyMode && !isCurrentlyInInput()) {
     if (e.key === 'j') {
-      window.scrollBy(0, 60)
+      window.scrollBy(0, scrollAmount)
     } else if (e.key === 'k') {
-      window.scrollBy(0, -60)
+      window.scrollBy(0, -scrollAmount)
+    } else if (e.key === 'd') {
+      window.scrollBy(0, quickScrollAmount)
+    } else if (e.key === 'u') {
+      window.scrollBy(0, -quickScrollAmount)
     }
   }
 })
 
 const commandChars = new Set(['f', 'F', 'y', 'g', 'G', 'c'])
-const linkChars = new Set(alphabet)
 document.addEventListener('keyup', function (e) {
   if (e.key === 'Escape' && isLinkKeyMode) {
     hideLinkKeys()
@@ -215,14 +223,6 @@ document.addEventListener('keyup', function (e) {
         showLinkKeys()
         blockKeybindings.select()
         linkAction = 'copyToClipboard'
-        break
-      // Use j to scroll down
-      case 'j':
-        window.scrollBy(0, 60)
-        break
-      // Use k to scroll up
-      case 'k':
-        window.scrollBy(0, -60)
         break
       case 'yy':
         copyUrlToClipboard()

--- a/vim-mode.js
+++ b/vim-mode.js
@@ -198,6 +198,7 @@ document.addEventListener('keydown', function (e) {
 })
 
 const commandChars = new Set(['f', 'F', 'y', 'g', 'G', 'c'])
+const linkChars = new Set(alphabet)
 document.addEventListener('keyup', function (e) {
   if (e.key === 'Escape' && isLinkKeyMode) {
     hideLinkKeys()


### PR DESCRIPTION
Adds quick scrolling actions and sensible defaults. Also removes the keyup event for scrolling as that's not what Vim does.